### PR TITLE
added script to help analyze your tech stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Looking for some inspo? Check out these amazing portfolios made using this templ
 -   [Next.js Docs](https://nextjs.org/docs) - For when you need to level up your Next.js skills.
 -   [Framer Motion](https://www.framer.com/motion/) - Bring your animations to life!
 -   [TailwindCSS Docs](https://tailwindcss.com/docs) - The most efficient way to style your projects without the fuss.
+-   [Analyzer](https://github.com/atzinescandia/atzin-escandia-devfolio/blob/main/scripts/analyzer.rs) - A Rust script you can run to analyze your local folders and generate a list of tech stacks for you. 
 
 ---
 

--- a/scripts/analyzer.rs
+++ b/scripts/analyzer.rs
@@ -1,0 +1,606 @@
+#!/usr/bin/env -S cargo +nightly -Zscript --quiet
+---cargo
+[package]
+edition = "2024"
+[dependencies]
+clap = { version = "4.2", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+rayon = "1.7"
+walkdir = "2.4"
+regex = "1.10"
+anyhow = "1.0"
+---
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use rayon::prelude::*;
+use regex::Regex;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use walkdir::{DirEntry, WalkDir};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "tech-stack-analyzer",
+    about = "Analyze tech stack in development folders",
+    version = "1.0"
+)]
+struct Args {
+    /// Path to analyze (default: current directory)
+    #[arg(default_value = ".")]
+    path: PathBuf,
+
+    /// Number of worker threads
+    #[arg(short, long, default_value_t = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(4))]
+    workers: usize,
+
+    /// Save results to JSON file
+    #[arg(short, long)]
+    output: Option<PathBuf>,
+
+    /// Only output JSON, no pretty printing
+    #[arg(short, long)]
+    quiet: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct FileAnalysis {
+    file_path: String,
+    language: String,
+    dependencies: Vec<String>,
+    size: usize,
+    lines: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct DependencyInfo {
+    name: String,
+    count: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct LanguageInfo {
+    name: String,
+    file_count: usize,
+    total_lines: usize,
+    total_size: usize,
+    top_dependencies: Vec<DependencyInfo>,
+}
+
+#[derive(Debug, Serialize)]
+struct Summary {
+    total_files_analyzed: usize,
+    total_lines_of_code: usize,
+    total_code_size_bytes: usize,
+    languages_found: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct AnalysisResults {
+    summary: Summary,
+    languages: Vec<LanguageInfo>,
+    top_dependencies_overall: Vec<DependencyInfo>,
+}
+
+struct TechStackAnalyzer {
+    root_path: PathBuf,
+    language_extensions: HashMap<&'static str, &'static str>,
+    skip_directories: Vec<&'static str>,
+    import_regexes: HashMap<&'static str, Vec<Regex>>,
+    quiet: bool,
+}
+
+impl TechStackAnalyzer {
+    fn new(root_path: PathBuf, quiet: bool) -> Result<Self> {
+        let language_extensions = [
+            (".py", "Python"),
+            (".js", "JavaScript"),
+            (".ts", "TypeScript"),
+            (".jsx", "React/JSX"),
+            (".tsx", "React/TSX"),
+            (".rs", "Rust"),
+            (".go", "Go"),
+            (".java", "Java"),
+            (".c", "C"),
+            (".cpp", "C++"),
+            (".cc", "C++"),
+            (".cxx", "C++"),
+            (".h", "C/C++ Header"),
+            (".hpp", "C++ Header"),
+            (".cs", "C#"),
+            (".rb", "Ruby"),
+            (".php", "PHP"),
+            (".swift", "Swift"),
+            (".kt", "Kotlin"),
+            (".scala", "Scala"),
+            (".clj", "Clojure"),
+            (".ex", "Elixir"),
+            (".exs", "Elixir"),
+            (".hs", "Haskell"),
+            (".ml", "OCaml"),
+            (".fs", "F#"),
+            (".r", "R"),
+            (".dart", "Dart"),
+            (".lua", "Lua"),
+            (".sh", "Shell Script"),
+            (".bash", "Bash"),
+            (".zsh", "Zsh"),
+            (".fish", "Fish"),
+            (".ps1", "PowerShell"),
+            (".sql", "SQL"),
+            (".html", "HTML"),
+            (".css", "CSS"),
+            (".scss", "SCSS"),
+            (".sass", "SASS"),
+            (".less", "LESS"),
+            (".vue", "Vue.js"),
+            (".svelte", "Svelte"),
+            (".elm", "Elm"),
+            (".nim", "Nim"),
+            (".zig", "Zig"),
+            (".toml", "TOML Config"),
+            (".yaml", "YAML Config"),
+            (".yml", "YAML Config"),
+            (".json", "JSON Config"),
+            (".xml", "XML"),
+            (".dockerfile", "Docker"),
+            (".tf", "Terraform"),
+            (".hcl", "HCL"),
+        ]
+        .into_iter()
+        .collect();
+
+        let skip_directories = vec![
+            "node_modules",
+            ".git",
+            ".svn",
+            ".hg",
+            "__pycache__",
+            ".pytest_cache",
+            "target",
+            "build",
+            "dist",
+            ".next",
+            ".nuxt",
+            ".idea",
+            ".vscode",
+            ".vs",
+            "vendor",
+            "deps",
+            "_build",
+        ];
+
+        // Compile regexes for import detection
+        let mut import_regexes: HashMap<&'static str, Vec<Regex>> = HashMap::new();
+
+        import_regexes.insert(
+            "Python",
+            vec![
+                Regex::new(r"^\s*import\s+([a-zA-Z_][a-zA-Z0-9_]*)")?,
+                Regex::new(r"^\s*from\s+([a-zA-Z_][a-zA-Z0-9_]*)\s+import")?,
+            ],
+        );
+
+        import_regexes.insert(
+            "JavaScript",
+            vec![
+                Regex::new(r#"^\s*import\s+.*?\s+from\s+['"]([^'"]+)['"]"#)?,
+                Regex::new(r#"^\s*const\s+.*?\s*=\s*require\(['"]([^'"]+)['"]\)"#)?,
+                Regex::new(r#"^\s*import\(['"]([^'"]+)['"]\)"#)?,
+            ],
+        );
+
+        import_regexes.insert(
+            "TypeScript",
+            vec![
+                Regex::new(r#"^\s*import\s+.*?\s+from\s+['"]([^'"]+)['"]"#)?,
+                Regex::new(r#"^\s*import\(['"]([^'"]+)['"]\)"#)?,
+            ],
+        );
+
+        import_regexes.insert(
+            "React/JSX",
+            vec![Regex::new(r#"^\s*import\s+.*?\s+from\s+['"]([^'"]+)['"]"#)?],
+        );
+
+        import_regexes.insert(
+            "React/TSX",
+            vec![Regex::new(r#"^\s*import\s+.*?\s+from\s+['"]([^'"]+)['"]"#)?],
+        );
+
+        import_regexes.insert(
+            "Rust",
+            vec![
+                Regex::new(r"^\s*use\s+([a-zA-Z_][a-zA-Z0-9_]*)")?,
+                Regex::new(r"^\s*extern\s+crate\s+([a-zA-Z_][a-zA-Z0-9_]*)")?,
+            ],
+        );
+
+        import_regexes.insert("Go", vec![Regex::new(r#"^\s*import\s+['"]([^'"]+)['"]"#)?]);
+
+        import_regexes.insert(
+            "Java",
+            vec![Regex::new(
+                r"^\s*import\s+([a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*)",
+            )?],
+        );
+
+        import_regexes.insert(
+            "C#",
+            vec![Regex::new(
+                r"^\s*using\s+([a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*)",
+            )?],
+        );
+
+        Ok(Self {
+            root_path,
+            language_extensions,
+            skip_directories,
+            import_regexes,
+            quiet,
+        })
+    }
+
+    fn print_status(&self, message: &str) {
+        if !self.quiet {
+            println!("{}", message);
+        }
+    }
+
+    fn get_file_language(&self, file_path: &Path) -> Option<&str> {
+        // Special case for Docker files
+        if let Some(name) = file_path.file_name().and_then(|n| n.to_str()) {
+            let lower_name = name.to_lowercase();
+            if lower_name == "dockerfile"
+                || lower_name == "dockerfile.dev"
+                || lower_name == "dockerfile.prod"
+            {
+                return Some("Docker");
+            }
+        }
+
+        file_path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .and_then(|ext| {
+                let ext_with_dot = format!(".{}", ext.to_lowercase());
+                self.language_extensions.get(ext_with_dot.as_str()).copied()
+            })
+    }
+
+    fn extract_dependencies(&self, content: &str, language: &str) -> Vec<String> {
+        let regexes = match self.import_regexes.get(language) {
+            Some(regexes) => regexes,
+            None => return Vec::new(),
+        };
+
+        let mut dependencies = Vec::new();
+
+        for line in content.lines() {
+            for regex in regexes {
+                for cap in regex.captures_iter(line) {
+                    if let Some(matched) = cap.get(1) {
+                        let mut dep = matched.as_str().to_string();
+
+                        // Clean up dependencies based on language
+                        match language {
+                            "Python" => {
+                                dep = dep.split('.').next().unwrap_or(&dep).to_string();
+                            }
+                            "JavaScript" | "TypeScript" | "React/JSX" | "React/TSX" => {
+                                // Skip relative imports
+                                if dep.starts_with("./") || dep.starts_with("../") {
+                                    continue;
+                                }
+                            }
+                            "Rust" => {
+                                dep = dep.split("::").next().unwrap_or(&dep).to_string();
+                                // Skip internal Rust modules
+                                if ["crate", "self", "super"].contains(&dep.as_str()) {
+                                    continue;
+                                }
+                            }
+                            "Java" => {
+                                dep = dep.split('.').next().unwrap_or(&dep).to_string();
+                            }
+                            _ => {}
+                        }
+
+                        if !dep.is_empty() {
+                            dependencies.push(dep);
+                        }
+                    }
+                }
+            }
+        }
+
+        dependencies
+    }
+
+    fn should_skip_dir(&self, entry: &DirEntry) -> bool {
+        if let Some(name) = entry.file_name().to_str() {
+            self.skip_directories.contains(&name)
+        } else {
+            false
+        }
+    }
+
+    fn analyze_file(&self, file_path: &Path) -> Option<FileAnalysis> {
+        let language = self.get_file_language(file_path)?;
+
+        let content = fs::read_to_string(file_path).ok()?;
+
+        // Skip empty files or very large files (>1MB)
+        if content.trim().is_empty() || content.len() > 1024 * 1024 {
+            return None;
+        }
+
+        let dependencies = self.extract_dependencies(&content, language);
+        let lines = content.lines().count();
+
+        Some(FileAnalysis {
+            file_path: file_path.to_string_lossy().to_string(),
+            language: language.to_string(),
+            dependencies,
+            size: content.len(),
+            lines,
+        })
+    }
+
+    fn collect_files(&self) -> Result<Vec<PathBuf>> {
+        self.print_status(&format!("🔍 Scanning {}...", self.root_path.display()));
+
+        let mut files = Vec::new();
+        let mut skipped_dirs = std::collections::HashSet::new();
+
+        for entry in WalkDir::new(&self.root_path).into_iter().filter_entry(|e| {
+            if e.file_type().is_dir() && self.should_skip_dir(e) {
+                if let Some(name) = e.file_name().to_str() {
+                    skipped_dirs.insert(name.to_string());
+                }
+                false
+            } else {
+                true
+            }
+        }) {
+            let entry = entry.context("Failed to read directory entry")?;
+            if entry.file_type().is_file() {
+                files.push(entry.into_path());
+            }
+        }
+
+        if !skipped_dirs.is_empty() {
+            let common_skipped: Vec<_> = skipped_dirs
+                .iter()
+                .filter(|&d| {
+                    ["node_modules", ".git", "target", "build", "dist"].contains(&d.as_str())
+                })
+                .collect();
+
+            if !common_skipped.is_empty() {
+                self.print_status(&format!(
+                    "⏭️  Skipping common directories: {}",
+                    common_skipped
+                        .iter()
+                        .map(|s| s.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+            }
+        }
+
+        self.print_status(&format!("📁 Found {} files to analyze", files.len()));
+        Ok(files)
+    }
+
+    fn analyze_codebase(&self) -> Result<AnalysisResults> {
+        let files = self.collect_files()?;
+
+        // Use rayon for parallel processing
+        let results: Vec<FileAnalysis> = files
+            .par_iter()
+            .filter_map(|file_path| self.analyze_file(file_path))
+            .collect();
+
+        Ok(self.aggregate_results(results))
+    }
+
+    fn aggregate_results(&self, results: Vec<FileAnalysis>) -> AnalysisResults {
+        if results.is_empty() {
+            return AnalysisResults {
+                summary: Summary {
+                    total_files_analyzed: 0,
+                    total_lines_of_code: 0,
+                    total_code_size_bytes: 0,
+                    languages_found: 0,
+                },
+                languages: Vec::new(),
+                top_dependencies_overall: Vec::new(),
+            };
+        }
+
+        // Collect stats per language
+        let mut language_stats: HashMap<String, (usize, usize, usize)> = HashMap::new(); // (file_count, total_lines, total_size)
+        let mut language_deps: HashMap<String, HashMap<String, usize>> = HashMap::new();
+        let mut all_dependencies: HashMap<String, usize> = HashMap::new();
+
+        for result in &results {
+            let (file_count, total_lines, total_size) = language_stats
+                .entry(result.language.clone())
+                .or_insert((0, 0, 0));
+
+            *file_count += 1;
+            *total_lines += result.lines;
+            *total_size += result.size;
+
+            let lang_deps = language_deps
+                .entry(result.language.clone())
+                .or_insert_with(HashMap::new);
+
+            for dep in &result.dependencies {
+                *lang_deps.entry(dep.clone()).or_insert(0) += 1;
+                *all_dependencies.entry(dep.clone()).or_insert(0) += 1;
+            }
+        }
+
+        // Convert to LanguageInfo structs and sort by file count
+        let mut languages: Vec<LanguageInfo> = language_stats
+            .into_iter()
+            .map(|(name, (file_count, total_lines, total_size))| {
+                let binding = HashMap::new();
+                let deps = language_deps.get(&name).unwrap_or(&binding);
+                let mut deps_vec: Vec<_> = deps
+                    .iter()
+                    .map(|(k, v)| DependencyInfo {
+                        name: k.clone(),
+                        count: *v,
+                    })
+                    .collect();
+                deps_vec.sort_by(|a, b| b.count.cmp(&a.count));
+                deps_vec.truncate(20); // Keep top 20
+
+                LanguageInfo {
+                    name,
+                    file_count,
+                    total_lines,
+                    total_size,
+                    top_dependencies: deps_vec,
+                }
+            })
+            .collect();
+
+        // Sort languages by file count
+        languages.sort_by(|a, b| b.file_count.cmp(&a.file_count));
+
+        // Sort overall dependencies
+        let mut top_dependencies_overall: Vec<DependencyInfo> = all_dependencies
+            .into_iter()
+            .map(|(name, count)| DependencyInfo { name, count })
+            .collect();
+        top_dependencies_overall.sort_by(|a, b| b.count.cmp(&a.count));
+        top_dependencies_overall.truncate(30); // Keep top 30
+
+        let total_files = results.len();
+        let total_lines: usize = results.iter().map(|r| r.lines).sum();
+        let total_size: usize = results.iter().map(|r| r.size).sum();
+
+        AnalysisResults {
+            summary: Summary {
+                total_files_analyzed: total_files,
+                total_lines_of_code: total_lines,
+                total_code_size_bytes: total_size,
+                languages_found: languages.len(),
+            },
+            languages,
+            top_dependencies_overall,
+        }
+    }
+
+    fn print_results(&self, results: &AnalysisResults) {
+        println!("\n{}", "=".repeat(60));
+        println!("🚀 TECH STACK ANALYSIS RESULTS");
+        println!("{}", "=".repeat(60));
+
+        let summary = &results.summary;
+        println!("\n📊 SUMMARY:");
+        println!(
+            "   • Files analyzed: {}",
+            format_number(summary.total_files_analyzed)
+        );
+        println!(
+            "   • Lines of code: {}",
+            format_number(summary.total_lines_of_code)
+        );
+        println!(
+            "   • Code size: {:.1} MB",
+            summary.total_code_size_bytes as f64 / 1024.0 / 1024.0
+        );
+        println!("   • Languages found: {}", summary.languages_found);
+
+        println!("\n🗣️  LANGUAGES BY USAGE:");
+        let total_files = summary.total_files_analyzed as f64;
+
+        for (i, lang_info) in results.languages.iter().enumerate() {
+            let percent = (lang_info.file_count as f64 / total_files) * 100.0;
+            println!(
+                "   {:2}. {:15} {:>6} files ({:5.1}%) - {:>8} lines",
+                i + 1,
+                lang_info.name,
+                lang_info.file_count,
+                percent,
+                format_number(lang_info.total_lines)
+            );
+        }
+
+        println!("\n📦 TOP DEPENDENCIES (All Languages):");
+        for (i, dep_info) in results.top_dependencies_overall.iter().take(15).enumerate() {
+            println!(
+                "   {:2}. {:25} {:>4} occurrences",
+                i + 1,
+                dep_info.name,
+                dep_info.count
+            );
+        }
+
+        println!("\n🔍 LANGUAGE-SPECIFIC DEPENDENCIES:");
+        for lang_info in &results.languages {
+            if !lang_info.top_dependencies.is_empty() {
+                println!("\n   {}:", lang_info.name);
+                for dep_info in lang_info.top_dependencies.iter().take(10) {
+                    println!("      • {:20} {:>3}x", dep_info.name, dep_info.count);
+                }
+            }
+        }
+    }
+}
+
+fn format_number(n: usize) -> String {
+    if n < 1000 {
+        n.to_string()
+    } else if n < 1_000_000 {
+        format!("{},{:03}", n / 1000, n % 1000)
+    } else {
+        format!(
+            "{},{:03},{:03}",
+            n / 1_000_000,
+            (n % 1_000_000) / 1000,
+            n % 1000
+        )
+    }
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    // Set up rayon thread pool if specified
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(args.workers)
+        .build_global()
+        .context("Failed to initialize thread pool")?;
+
+    let analyzer =
+        TechStackAnalyzer::new(args.path, args.quiet).context("Failed to initialize analyzer")?;
+
+    let results = analyzer
+        .analyze_codebase()
+        .context("Failed to analyze codebase")?;
+
+    if let Some(output_path) = args.output {
+        let json_output =
+            serde_json::to_string_pretty(&results).context("Failed to serialize results")?;
+        fs::write(&output_path, json_output).context("Failed to write output file")?;
+        analyzer.print_status(&format!("💾 Results saved to {}", output_path.display()));
+    }
+
+    if args.quiet {
+        let json_output = serde_json::to_string(&results).context("Failed to serialize results")?;
+        println!("{}", json_output);
+    } else {
+        analyzer.print_results(&results);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Added a standalone Rust executable script that will generate a list of languages and information about technologies you use most. I work with a lot of technologies and it's often hard to list out everything, so I wrote this for myself, maybe it will be helpful for others.

While it is written in Rust, so long as you have Rust installed, you can run it like a shell script. I originally wrote it in Bash, but that was terribly slow. I then tried Python, but that was also really slow. This completes in a few seconds and requires no extra effort from the end user.

By default, it will pretty print, but it also supports JSON and saving to a file. It uses a parallel worker pool based on the number of CPUs you have; I have 10 on my M1 Macbook, but it will show more or less based on whomever is running it. The parallelization is necessary, it can process my entire development folder in about 2 seconds.

Here is the help menu:

```sh
$ ./scripts/analyzer.rs --help
Analyze tech stack in development folders

Usage: analyzer [OPTIONS] [PATH]

Arguments:
  [PATH]  Path to analyze (default: current directory) [default: .]

Options:
  -w, --workers <WORKERS>  Number of worker threads [default: 10]
  -o, --output <OUTPUT>    Save results to JSON file
  -q, --quiet              Only output JSON, no pretty printing
  -h, --help               Print help
  -V, --version            Print version
```

And here is what it looks like running on my machine:

```sh
$ ./scripts/analyzer.rs ~/Development
🔍 Scanning /Users/sienna/Development...
⏭️  Skipping common directories: .git, build, target, dist, node_modules
📁 Found 90184 files to analyze

============================================================
🚀 TECH STACK ANALYSIS RESULTS
============================================================

📊 SUMMARY:
   • Files analyzed: 42,173
   • Lines of code: 12,478,398
   • Code size: 451.8 MB
   • Languages found: 41

🗣️  LANGUAGES BY USAGE:
    1. Python           13368 files ( 31.7%) - 5,778,091 lines
    2. C/C++ Header      9944 files ( 23.6%) -  822,258 lines
    3. Rust              3030 files (  7.2%) - 1,108,399 lines
    4. React/TSX         2951 files (  7.0%) -  334,671 lines
    5. Swift             2747 files (  6.5%) - 1,636,468 lines
    6. JSON Config       2227 files (  5.3%) - 1,145,711 lines
    7. TypeScript        2064 files (  4.9%) -  249,358 lines
    8. C#                 981 files (  2.3%) -   62,830 lines
    9. C++                866 files (  2.1%) -  583,381 lines
   10. TOML Config        512 files (  1.2%) -   21,475 lines
   11. Go                 454 files (  1.1%) -  109,863 lines
   12. YAML Config        447 files (  1.1%) -  123,668 lines
   13. Shell Script       407 files (  1.0%) -   21,351 lines
   14. C                  369 files (  0.9%) -  183,330 lines
   15. Java               351 files (  0.8%) -   74,643 lines
   16. SQL                305 files (  0.7%) -    9,906 lines
   17. JavaScript         256 files (  0.6%) -   47,557 lines
   18. Terraform          179 files (  0.4%) -   73,999 lines
   19. CSS                143 files (  0.3%) -   20,696 lines
   20. Kotlin             141 files (  0.3%) -   13,308 lines
   21. HTML               120 files (  0.3%) -   23,791 lines
   22. XML                 82 files (  0.2%) -    7,917 lines
   23. C++ Header          55 files (  0.1%) -    9,888 lines
   24. SCSS                43 files (  0.1%) -    7,560 lines
   25. Dart                31 files (  0.1%) -    2,864 lines
   26. Docker              23 files (  0.1%) -      659 lines
   27. HCL                 14 files (  0.0%) -      217 lines
   28. React/JSX           14 files (  0.0%) -      439 lines
   29. Svelte              14 files (  0.0%) -      859 lines
   30. PowerShell           8 files (  0.0%) -    1,209 lines
   31. Vue.js               8 files (  0.0%) -      447 lines
   32. Fish                 4 files (  0.0%) -      476 lines
   33. Haskell              2 files (  0.0%) -       20 lines
   34. PHP                  2 files (  0.0%) -       20 lines
   35. Ruby                 2 files (  0.0%) -       18 lines
   36. SASS                 2 files (  0.0%) -       28 lines
   37. Scala                2 files (  0.0%) -       26 lines
   38. Lua                  2 files (  0.0%) -      417 lines
   39. Zsh                  1 files (  0.0%) -      212 lines
   40. Bash                 1 files (  0.0%) -      338 lines
   41. Elixir               1 files (  0.0%) -       30 lines

📦 TOP DEPENDENCIES (All Languages):
    1. typing                    5195 occurrences
    2. std                       4170 occurrences
    3. torch                     4092 occurrences
    4. numpy                     3075 occurrences
    5. pandas                    2559 occurrences
    6. __future__                2316 occurrences
    7. os                        1943 occurrences
    8. sys                       1817 occurrences
    9. pytest                    1664 occurrences
   10. react                     1633 occurrences
   11. ui                        1531 occurrences
   12. collections               1305 occurrences
   13. functools                 1235 occurrences
   14. re                        1148 occurrences
   15. warnings                  1115 occurrences

🔍 LANGUAGE-SPECIFIC DEPENDENCIES:

   Python:
      • typing               5195x
      • torch                4092x
      • numpy                3075x
      • pandas               2559x
      • __future__           2316x
      • os                   1943x
      • sys                  1817x
      • pytest               1664x
      • functools            1235x
      • re                   1148x

   Rust:
      • std                  4170x
      • gpui                 767x
      • openraft             760x
      • anyhow               596x
      • deno_core            487x
      • serde                452x
      • util                 370x
      • futures              334x
      • language             279x
      • tokio                273x

   React/TSX:
      • react                1486x
      • ui                   1276x
      • lucide-react         941x
      • common               541x
      • next/link            465x
      • sonner               286x
      • next/router          224x
      • @supabase/shared-types/out/constants 194x
      • types                188x
      • hooks/misc/useCheckPermissions 184x

   TypeScript:
      • @tanstack/react-query 422x
      • types                376x
      • data/fetchers        310x
      • sonner               227x
      • react                117x
      • vitest                93x
      • next                  87x
      • lib/constants         84x
      • data/sql/execute-sql-query  81x
      • @supabase/supabase-js  72x

   C#:
      • WorkflowCore.Interface 280x
      • System               269x
      • WorkflowCore.Models  257x
      • System.Linq          191x
      • Xunit                170x
      • System.Reflection    162x
      • System.Threading.Tasks 158x
      • System.Collections.Generic 132x
      • Microsoft.Extensions.DependencyInjection 110x
      • WorkflowCore.IntegrationTests.Scenarios  85x

   Go:
      • fmt                    6x
      • github.com/supabase/auth/internal/api   5x
      • testing                2x
      • strings                1x
      • net/http               1x
      • time                   1x

   Java:
      • org                  479x
      • java                 441x
      • static               188x
      • io                    30x
      • com                    7x
      • javax                  2x

   JavaScript:
      • ext:core/mod.js       23x
      • react                 21x
      • @supabase/supabase-js  10x
      • @payloadcms/richtext-lexical/client  10x
      • path                   8x
      • fs                     7x
      • ~/lib/Store            6x
      • ~/lib/UserContext      6x
      • node:process           5x
      • ext:deno_node/internal/util.mjs   5x

   React/JSX:
      • react                  9x
      • vitest                 6x
      • @testing-library/react   4x
      • @sentry/nextjs         1x
      • react-dom/client       1x
      • next/error             1x
```

It is not perfect, but it's a start, and might be helpful for others. If you aren't familiar with Rust and want help supporting it, I'm happy to add a `CODEOWNERS` file so that I get tagged when people need help or want to submit patches for it.